### PR TITLE
Pass max message size to ws implementation

### DIFF
--- a/src/ToolSocket.js
+++ b/src/ToolSocket.js
@@ -92,7 +92,9 @@ class ToolSocket {
         const searchParams = new URLSearchParams({networkID: this.networkId});
         this.url = addSearchParams(url, searchParams);
 
-        this.socket = new WebSocketWrapper(this.url);
+        this.socket = new WebSocketWrapper(this.url, [], {
+            maxPayload: MAX_MESSAGE_SIZE,
+        });
         this.configureSocket();
     }
 


### PR DESCRIPTION
The ws implementation (even as a client) needs to know that we're about to tell it to deal with outrageously overwised messages.